### PR TITLE
Support requesting a definition other than the first

### DIFF
--- a/sopel_modules/urban/urban.py
+++ b/sopel_modules/urban/urban.py
@@ -7,8 +7,13 @@ from sopel.module import commands, example
 from sopel.tools import get_sendable_message  # added in Sopel 6.6.2
 
 
-def display(bot, term, data):
-    definition = data['list'][0]['definition']
+def display(bot, term, data, num=1):
+    try:
+        definition = data['list'][num - 1]['definition']
+    except IndexError:
+        bot.reply("Requested definition does not exist. Try a lower number.")
+        return
+
     # This guesswork nonsense can be replaced with `bot.say()`'s `trailing`
     # parameter when dropping support for Sopel <7.1
     msg, excess = get_sendable_message(
@@ -33,13 +38,29 @@ def get_definition(bot, term):
 @commands('ud', 'urban')
 @example('.urban fronking', '[urban] fronking - If [your name] is [Hunter] you are a [fronker].')
 def urban(bot, trigger):
-    term = trigger.group(2)
+    term, _, num = trigger.group(2).partition('/')
+
+    if num:
+        try:
+            num = int(num)
+        except ValueError:
+            bot.reply("'{}' is not a valid definition number.".format(num))
+            return
+
+        if num < 1 or num > 10:
+            bot.reply("Try a definition number in the range 1-10.")
+            return
+
+        term = term.strip()
+    else:
+        num = 1
+
     # Get data from API
     data = get_definition(bot, term)
     # Have the bot print the data
     if data:
         if 'list' in data.keys() and len(data['list']) > 0:
-            display(bot, term, data)
+            display(bot, term, data, num)
         else:
             # No result; display error
             bot.reply("Sorry, no results.")


### PR DESCRIPTION
Tin. Very much inspired by how Rizon's Internets bot works. Not sure the best way to document this option, since adding another `@example` would just add another point of failure for tests (definitions may change order or wording at any time; see e66884c8e0b526e23555f25005856e783caaff57).