### PR TITLE
Fix regression for empty input

### DIFF
--- a/sopel_modules/urban/urban.py
+++ b/sopel_modules/urban/urban.py
@@ -38,7 +38,10 @@ def get_definition(bot, term):
 @commands('ud', 'urban')
 @example('.urban fronking', '[urban] fronking - If [your name] is [Hunter] you are a [fronker].')
 def urban(bot, trigger):
-    term, _, num = trigger.group(2).partition('/')
+    if not trigger.group(2):
+        term = num = None
+    else:
+        term, _, num = trigger.group(2).partition('/')
 
     if num:
         try:


### PR DESCRIPTION
Intentional or not, it was a nice Easter egg before when doing just the '.ud' command with no parameter would fetch and display the definition for 'none' (currently, "None - [The lack] of [anything]").

My last patch (a way to request definitions other than the top one) managed to break this. I didn't account for the empty-input case. Consider this patch an apology; it restores the previous behavior.

@RustyBower 🙇‍♂️ Please accept my contrition. 🙇‍♂️